### PR TITLE
Add Dockerfile, cryptography requirement to testsite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
 FROM python:3.7-slim-bullseye
-ENV VIRTUAL_ENV="/opt/deployutils"
+ENV VIRTUAL_ENV="/app"
 RUN python -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin${PATH:+:}$PATH"
-COPY . $VIRTUAL_ENV/djaodjin-deployutils/
-WORKDIR $VIRTUAL_ENV/djaodjin-deployutils
+COPY . $VIRTUAL_ENV/reps/djaodjin-deployutils/
+WORKDIR $VIRTUAL_ENV/reps/djaodjin-deployutils
 RUN set -eux;\
       apt-get update; \
       apt-get install -y --no-install-recommends make; \
@@ -16,4 +16,4 @@ RUN set -eux;\
       apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
       rm -rf /var/lib/apt/lists/*;
 EXPOSE 80/tcp
-ENTRYPOINT ["/opt/deployutils/bin/python", "/opt/deployutils/djaodjin-deployutils/manage.py", "runserver", "0.0.0.0:80"]
+ENTRYPOINT ["/app/bin/python", "/app/reps/djaodjin-deployutils/manage.py", "runserver", "0.0.0.0:80"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+FROM python:3.7-slim-bullseye
+WORKDIR /
+RUN mkdir -p /opt/virtualenv
+ENV VIRTUAL_ENV="/opt/virtualenv/_installTop_"
+RUN python -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin${PATH:+:}$PATH"
+COPY . $VIRTUAL_ENV/djaodjin-deployutils/
+WORKDIR $VIRTUAL_ENV/djaodjin-deployutils
+RUN set -eux;\
+      apt-get update; \
+      apt-get install -y --no-install-recommends make; \
+      \
+      pip install -r testsite/requirements.txt; \
+      \
+      make initdb; \
+      \
+      apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+      rm -rf /var/lib/apt/lists/*;
+EXPOSE 8000/tcp
+ENTRYPOINT ["/opt/virtualenv/_installTop_/bin/python", "/opt/virtualenv/_installTop_/djaodjin-deployutils/manage.py", "runserver", "0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 # syntax=docker/dockerfile:1
 FROM python:3.7-slim-bullseye
-WORKDIR /
-RUN mkdir -p /opt/virtualenv
-ENV VIRTUAL_ENV="/opt/virtualenv/_installTop_"
+ENV VIRTUAL_ENV="/opt/deployutils"
 RUN python -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin${PATH:+:}$PATH"
 COPY . $VIRTUAL_ENV/djaodjin-deployutils/
@@ -17,5 +15,5 @@ RUN set -eux;\
       \
       apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
       rm -rf /var/lib/apt/lists/*;
-EXPOSE 8000/tcp
-ENTRYPOINT ["/opt/virtualenv/_installTop_/bin/python", "/opt/virtualenv/_installTop_/djaodjin-deployutils/manage.py", "runserver", "0.0.0.0:8000"]
+EXPOSE 80/tcp
+ENTRYPOINT ["/opt/deployutils/bin/python", "/opt/deployutils/djaodjin-deployutils/manage.py", "runserver", "0.0.0.0:80"]

--- a/testsite/requirements.txt
+++ b/testsite/requirements.txt
@@ -4,7 +4,7 @@ Jinja2==3.1.1
 PyJWT==2.3.0
 python-dateutil==2.8.2
 monotonic==1.1
-cryptography>=2.2.2
+cryptography==37.0.2
 
 # When DEBUG=1
 django-debug-toolbar==3.2.4  # required by Django==4.0

--- a/testsite/requirements.txt
+++ b/testsite/requirements.txt
@@ -4,6 +4,7 @@ Jinja2==3.1.1
 PyJWT==2.3.0
 python-dateutil==2.8.2
 monotonic==1.1
+cryptography>=2.2.2
 
 # When DEBUG=1
 django-debug-toolbar==3.2.4  # required by Django==4.0


### PR DESCRIPTION
Add the ability to run `testsite` as a docker image for development and
testing. Dockerfile retains the use of a `$VIRTUAL_ENV` for consistency
with pre-existing non-docker environments. The `venv` module is used
instead of the `virtualenv` standalone program to avoid the dependency
overhead of installing additional Debian packages. `Testsite` is
initialized to serve all IPs in order to work with Docker's network
proxy.

Add the `cryptography` module to testsite/requirements.txt to take
advantage of the space-saving and dependency resolution improvements of
pre-built wheel packages over Debian packages. See
[https://www.djaodjin.com/blog/packaging-python-app.blog.html]()