### PR TITLE
Two different styles of supporting multiple package and python versions. Take your pick :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,11 @@ Tested with
 
 - **Python:** 3.7, **Django:** 3.2 ([LTS](https://www.djangoproject.com/download/))
 - **Python:** 3.10, **Django:** 4.2 (latest)
+- **Python:** 3.12, **Django:** 5.1 (next)
 - **Python:** 2.7, **Django:** 1.11 (legacy) - use testsite/requirements-legacy.txt
 
-0.11.0
+0.12.0
 
-  * makes `manages_broker` a property (breaking change)
-  * fixes missing get_context_data
-  * adds message about env variables override
+  * adds support for Django 4.2(LTS) and 5.1
 
 [previous release notes](changelog)

--- a/changelog
+++ b/changelog
@@ -1,3 +1,9 @@
+0.12.0
+
+  * adds support for Django 4.2(LTS) and 5.1
+
+ -- Morgan Shorter <morgan@morganshorter.com> Wed, 22 Jan 2024 11:06:41 -800
+
 0.11.0
 
   * makes `manages_broker` a property (breaking change)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,12 @@ dependencies = [
 
 [project.optional-dependencies]
 django = [
+  "Django==3.2.24 ; python_version < '3.9'",
+  "Django==4.2.17 ; python_version >= '3.9' and python_version < '3.12'",
+  "Django==5.1.4 ; python_version >= '3.12'",
   "django-assets>=0.10",
-  "djangorestframework>=3.9.4",
+  "djangorestframework==3.14.0 ; python_version < '3.9'",
+  "djangorestframework==3.15.2 ; python_version >= '3.9'",
   "jinja2>=2.8.1",
   # when you use the timers mixins
   "monotonic>=1.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/testsite/requirements-3.12.txt
+++ b/testsite/requirements-3.12.txt
@@ -1,0 +1,26 @@
+# Python 3.12 / Django 5.1; complete file
+Django==5.1.4
+djangorestframework==3.15.2
+Jinja2==3.1.3
+PyJWT==2.6.0
+python-dateutil==2.8.2
+pytz ~= 2024.2
+monotonic==1.6
+cryptography==42.0.4
+
+# When DEBUG=1
+# django-debug-toolbar~=5.0.0-alpha # 5.x will support Django 5.1 and Python 3.12
+django-debug-toolbar==4.4.6       # 4.4.6 is the most recent release
+                                  # 3.4.0 requires Django>=3.2
+                                  # 3.2.4 fails with SQLPanel is not scriptable
+                                  # 2.2.1 is the last version for Django2.2
+                                  # 1.11 does not support Django 2.2
+django-extensions==3.2.3          # required by Django==4.0
+
+# So we can run pylint with no missing imports
+coverage==7.2.7
+Flask==2.2.5
+
+# development
+Sphinx==5.1.1
+sphinxcontrib-httpdomain==1.8.1

--- a/testsite/requirements-3.7.txt
+++ b/testsite/requirements-3.7.txt
@@ -1,0 +1,23 @@
+# Python 3.7 / Django 3.2; complete file
+Django==3.2.24
+djangorestframework==3.14.0
+Jinja2==3.1.3
+PyJWT==2.6.0
+python-dateutil==2.8.2
+monotonic==1.6
+cryptography==42.0.4
+
+# When DEBUG=1
+django-debug-toolbar==3.5.0       # 3.4.0 requires Django>=3.2
+                                  # 3.2.4 fails with SQLPanel is not scriptable
+                                  # 2.2.1 is the last version for Django2.2
+                                  # 1.11 does not support Django 2.2
+django-extensions==3.2.0          # required by Django==4.0
+
+# So we can run pylint with no missing imports
+coverage==7.2.7
+Flask==2.2.5
+
+# development
+Sphinx==5.1.1
+sphinxcontrib-httpdomain==1.8.1

--- a/testsite/requirements-3.9.txt
+++ b/testsite/requirements-3.9.txt
@@ -1,0 +1,29 @@
+# Python 3.9 / Django 4.2; complete file
+Django==4.2.17
+djangorestframework==3.15.2      # Pinned the micro version here,
+                                 # because there have been some
+                                 # breaking changes in the 3.15
+                                 # branch. Requires Django >=4.2 and
+                                 # Python >=3.8
+Jinja2==3.1.3
+PyJWT==2.6.0
+python-dateutil==2.8.2
+pytz ~= 2024.2
+monotonic==1.6
+cryptography==42.0.4
+
+# When DEBUG=1
+django-debug-toolbar==4.4.6       # 3.4.0 requires Django>=3.2
+                                  # 3.2.4 fails with SQLPanel is not scriptable
+                                  # 2.2.1 is the last version for Django2.2
+                                  # 1.11 does not support Django 2.2
+
+django-extensions==3.2.3          # required by Django==4.0
+
+# So we can run pylint with no missing imports
+coverage==7.2.7
+Flask==2.2.5
+
+# development
+Sphinx==5.1.1
+sphinxcontrib-httpdomain==1.8.1

--- a/testsite/requirements.txt
+++ b/testsite/requirements.txt
@@ -1,9 +1,9 @@
 # Unified requirements file supporting 3.7/3.2, 3.9/4.2, 3.12/5.1
 
-Django==3.2.24 ; python_version == "3.7"
-Django==4.2.17 ; python_version == "3.9"
-Django==5.1.4 ; python_version == "3.12"
-djangorestframework==3.14.0 ; python_version == "3.7"
+Django==3.2.24 ; python_version < "3.9"
+Django==4.2.17 ; python_version >= "3.9" and python_version < "3.12"
+Django==5.1.4 ; python_version >= "3.12"
+djangorestframework==3.14.0 ; python_version < "3.9"
 djangorestframework==3.15.2 ; python_version >= "3.9" # Breaking
                                             # changes in 3.15.0 and
                                             # 3.15.1. Requires Django
@@ -21,7 +21,7 @@ cryptography==42.0.4
 # When DEBUG=1
 # django-debug-toolbar~=5.0.0 ; python_version == "3.12"  # Currently in alpha
 django-debug-toolbar==4.4.6 ; python_version >= "3.9"
-django-debug-toolbar==3.5.0 ; python_version == "3.7" # 3.4.0 requires Django>=3.2
+django-debug-toolbar==3.5.0 ; python_version < "3.9" # 3.4.0 requires Django>=3.2
                                   # 3.2.4 fails with SQLPanel is not scriptable
                                   # 2.2.1 is the last version for Django2.2
                                   # 1.11 does not support Django 2.2

--- a/testsite/requirements.txt
+++ b/testsite/requirements.txt
@@ -1,17 +1,32 @@
-Django==3.2.24
-djangorestframework==3.14.0
+# Unified requirements file supporting 3.7/3.2, 3.9/4.2, 3.12/5.1
+
+Django==3.2.24 ; python_version == "3.7"
+Django==4.2.17 ; python_version == "3.9"
+Django==5.1.4 ; python_version == "3.12"
+djangorestframework==3.14.0 ; python_version == "3.7"
+djangorestframework==3.15.2 ; python_version >= "3.9" # Breaking
+                                            # changes in 3.15.0 and
+                                            # 3.15.1. Requires Django
+                                            # >=4.2 and Python >=3.8.
+
 Jinja2==3.1.3
 PyJWT==2.6.0
 python-dateutil==2.8.2
+pytz==2024.2 ; python_version >= "3.9" # This has been obviated by
+                                       # `zoneinfo' and `tzdata' since
+                                       # 3.9, but we still use it.
 monotonic==1.6
 cryptography==42.0.4
 
 # When DEBUG=1
-django-debug-toolbar==3.5.0       # 3.4.0 requires Django>=3.2
+# django-debug-toolbar~=5.0.0 ; python_version == "3.12"  # Currently in alpha
+django-debug-toolbar==4.4.6 ; python_version >= "3.9"
+django-debug-toolbar==3.5.0 ; python_version == "3.7" # 3.4.0 requires Django>=3.2
                                   # 3.2.4 fails with SQLPanel is not scriptable
                                   # 2.2.1 is the last version for Django2.2
                                   # 1.11 does not support Django 2.2
-django-extensions==3.2.0          # required by Django==4.0
+
+django-extensions==3.2.3          # required by Django==4.0
 
 # So we can run pylint with no missing imports
 coverage==7.2.7


### PR DESCRIPTION
Keeping things in separate files is easier if we want to test the same set of packages with different versions of python.  I.e., if I want run all three requirements files against Python 3.10, it requires no extra work (besides running my build script again).  If I want to do the same with the unified file, it would required some needlessly complex work-arounds.

On the other hand, having separate files breaks `pip install .` and probably some testing/ide conveniences e.g., `filetype`, `pip-requirements-mode`, etc.